### PR TITLE
Update stream_gcode.py for win10 correct colored output

### DIFF
--- a/stream_gcode.py
+++ b/stream_gcode.py
@@ -7,6 +7,8 @@ import os
 import serial
 import time
 
+os.system("") #To print colored output correctly on windows 10
+
 col_send = "\033[32m"
 col_recv = "\033[33m"
 col_error = "\033[31m"


### PR DESCRIPTION
Added ```os.system("")``` to print the implemented colored output functionality  correctly on different types Windows 10 terminals/consoles like PowerShell and CMD.exe.  It kept printing the values of the octal color codes rather than displaying in targeted color in my python console, PowerShell and cmd.